### PR TITLE
Fix failing unit tests

### DIFF
--- a/src/test/java/com/agiloak/mpi/index/persistence/LinkRecordTest.java
+++ b/src/test/java/com/agiloak/mpi/index/persistence/LinkRecordTest.java
@@ -192,46 +192,47 @@ public class LinkRecordTest {
 		
 		// Test finding Link Record by person and type
 		LinkRecord link = LinkRecordDAO.findByPersonAndType(conn, person.getId(), UKRDC_TYPE);
-		System.out.println("=========BEGIN TEST DEBUG=========");
-		System.out.println("lr.getId()");
-		System.out.println(lr.getId());
-		System.out.println("link.getId()");
-		System.out.println(link.getId());
-		System.out.println("=========END TEST DEBUG=========");
 		assert(lr.getId()==link.getId());
 	}
 
 	@Test
 	public void testCountByMasterAndOriginator() throws MpiException {
-		
+		// Create Person 1
 		Person person1 = new Person();
-		person1.setOriginator("TORG1").setLocalId("TST1000001").setLocalIdType("MR");
+		person1.setOriginator("TORG1").setLocalId("TST.I.P.LRT.CBMAO.1").setLocalIdType("MR");
 		person1.setTitle("MR").setGivenName("NICK").setSurname("JONES");
 		person1.setDateOfBirth(new Date());
 		person1.setGender("1");
 		PersonDAO.create(conn, person1);
 
+		// Create Person 2
 		Person person2 = new Person();
-		person2.setOriginator("TORG1").setLocalId("TST1000002").setLocalIdType("MR");
+		person2.setOriginator("TORG1").setLocalId("TST.I.P.LRT.CBMAO.2").setLocalIdType("MR");
 		person2.setTitle("MR").setGivenName("NICK").setSurname("JONES");
 		person2.setDateOfBirth(new Date());
 		person2.setGender("1");
 		PersonDAO.create(conn, person2);
 
+		// Create Master Record
 		MasterRecord mr = new MasterRecord();
 		mr.setNationalId(RR2).setNationalIdType(UKRDC_TYPE);
 		mr.setDateOfBirth(new Date());
 		mr.setEffectiveDate(new Date());
 		MasterRecordDAO.create(conn, mr);
-		LinkRecord lr = new LinkRecord(mr.getId(),person1.getId());
+
+		// Create Link Record 1
+		LinkRecord lr = new LinkRecord(mr.getId(), person1.getId());
 		LinkRecordDAO.create(conn, lr);
 		
+		// Test counting Link Records by master and originator
 		int count = LinkRecordDAO.countByMasterAndOriginator(conn, mr.getId(), "TORG1");
 		assert(count==1);
 	
+		// Create Link Record 2
 		lr = new LinkRecord(mr.getId(),person2.getId());
 		LinkRecordDAO.create(conn, lr);
 		
+		// Test counting Link Records by master and originator
 		count = LinkRecordDAO.countByMasterAndOriginator(conn, mr.getId(), "TORG1");
 		assert(count==2);
 


### PR DESCRIPTION
Honestly not sure how these were passing at all. I guess luck?

Fixes a unit test which only passed if the Person ID being tested was, by coincidence or a previous database persisting between tests, set to a specific hard-coded value.

Test changed to create a new person for the test, instead of relying on an existing one which may not exist, or may not have the expected ID.

I'm not assuming there will be more tests like this, so it's something I'd like to go back to when cleaning up the rest of the tests.